### PR TITLE
Add 3-pass Go production bug audit report

### DIFF
--- a/docs/bug-audit-2026-02-24.md
+++ b/docs/bug-audit-2026-02-24.md
@@ -1,0 +1,112 @@
+# Go Codebase True-Bug Audit (3 Pass)
+
+> Note: `snipe` is not available in this environment (`bash: snipe: command not found`), so reachability was proven with static call tracing from `main()` and targeted CLI behavior checks.
+
+## PASS 1 — True Bugs Audit (Correctness & Reliability)
+
+### System Map
+- **Entry points:** CLI subcommands dispatched by `main()` (`enqueue`, `claim`, `done`, `status`, `reset`).
+- **Persistence:** SQLite DB opened by `openDB()`, schema applied on startup.
+- **Concurrency model:** multi-process workers expected (README loop examples), no in-process goroutines in production code paths.
+- **Boundary calls:** filesystem reads (`fileHash`), SQL read/write (`db.Query`, `db.Exec`).
+- **Error style:** fatal exit for most DB/open errors; some row scan / JSON encode errors are ignored.
+
+### Findings
+
+1. **Revisit scheduling is never consumed by claim logic**  
+   **Severity:** High  
+   **Evidence:** `doneCmd()` writes `next_at` but always sets `done_at` non-NULL; `claimCmd()` only returns rows where `done_at IS NULL` and never checks due `next_at`.  
+   **Reachability:** `main()` → `doneCmd()` (`--revisit`) and `main()` → `claimCmd()` in normal CLI flow.  
+   **Mechanism:** Revisit items become permanently done and therefore unclaimable.  
+   **Concrete failure scenario:** Operators schedule periodic checks with `--revisit='+14 days'`; jobs never reappear, causing silent coverage gaps.  
+   **Minimal fix + tests:** Update claim predicate to include due revisits (e.g., `(done_at IS NULL OR (next_at IS NOT NULL AND next_at <= DATETIME('now')))`), and add integration test for done+revisit then claim after due time.  
+   **Confidence:** High.
+
+2. **`claim` is non-atomic and does not reserve work, enabling duplicate processing**  
+   **Severity:** High  
+   **Evidence:** `claimCmd()` performs pure `SELECT` and does not update state (no lease/claim marker). README demonstrates parallel workers invoking `claim` independently.  
+   **Reachability:** `main()` → `claimCmd()`; externally triggerable with two workers on same treatment/shard.  
+   **Mechanism:** Concurrent consumers can read identical pending rows before any `done` update.  
+   **Concrete failure scenario:** Two workers execute side-effecting checks/deploy actions on same file, causing duplicate external effects and inconsistent run accounting.  
+   **Minimal fix + tests:** Add lease columns (`claimed_at`, `claimed_by`) and claim in one transaction (`UPDATE ... WHERE ... LIMIT ... RETURNING` pattern), with concurrent test proving no duplicates.  
+   **Confidence:** High.
+
+3. **`done` succeeds even when target row does not exist**  
+   **Severity:** Medium  
+   **Evidence:** `doneCmd()` executes `UPDATE ... WHERE path_hash = ? AND treatment = ?` and never checks `RowsAffected()`.  
+   **Reachability:** `main()` → `doneCmd()` for any caller typo/path mismatch.  
+   **Mechanism:** Missed updates are silently treated as success.  
+   **Concrete failure scenario:** Worker passes relative path while queue stored absolute path hash; command exits 0 but item remains pending forever.  
+   **Minimal fix + tests:** Validate `RowsAffected()==1` (or >0) and fail otherwise; add test for nonexistent path expecting non-zero exit/error.  
+   **Confidence:** High.
+
+4. **Shard end boundary excludes a small but real key range**  
+   **Severity:** Medium  
+   **Evidence:** `calculateShardRange()` sets last `end` to `ffffffffffffffff` prefix padded with zeros; `claimCmd()` filters `path_hash < end`.  
+   **Reachability:** `main()` → `claimCmd()` with sharding flags.  
+   **Mechanism:** Hashes lexicographically greater than `ffffffffffffffff000...` (same 16-hex prefix + nonzero tail) are never selected by any shard.  
+   **Concrete failure scenario:** Rare paths hash into excluded suffix range and become permanently unclaimable under sharded operation.  
+   **Minimal fix + tests:** Use full 256-bit ranges or make final shard upper bound open-ended (`no upper bound`) / inclusive logic for final shard; add boundary hash tests around max values.  
+   **Confidence:** Medium.
+
+## PASS 2 — Concurrency & Lifecycle Audit
+
+### Concurrency Roots Inventory
+- No goroutines/channels in runtime code.
+- Operational concurrency is **multi-process** via parallel CLI workers (README sharding examples).
+- Lifecycle roots:
+  - Worker loop repeatedly executes `claim` then `done`.
+  - DB lifecycle per command: `openDB()` then deferred `Close()`.
+
+### Findings
+
+1. **Inter-process race: duplicate claims under concurrent workers**  
+   **Severity:** High  
+   **Evidence + lifecycle trace:** `main()` → `claimCmd()` (`SELECT` only) → worker external processing → `main()` → `doneCmd()` (`UPDATE`). No reservation state between claim and completion.  
+   **Mechanism:** Time-of-check/time-of-use race between independent processes.  
+   **Timeline scenario:** W1 and W2 run `claim` at t0, both get same path, both process, first done wins but side effects duplicated.  
+   **Minimal fix:** Transactional leasing with expiry and claimant identity.  
+   **Test strategy:** Spawn concurrent `claim` commands against same DB and assert disjoint returned sets.  
+   **Confidence:** High.
+
+2. **Busy-timeout + immediate fatal exits create fragile behavior during writer contention**  
+   **Severity:** Medium  
+   **Evidence + lifecycle trace:** `openDB()` sets `busy_timeout=3000`; command handlers exit on query/exec error.  
+   **Mechanism:** Under N workers, transient lock contention beyond 3s aborts work instead of retrying gracefully.  
+   **Timeline scenario:** Burst of `done` updates during compaction/slow I/O triggers `database is locked`; worker dies and queue throughput collapses.  
+   **Minimal fix:** Add retry loop with jitter around SQLITE_BUSY/LOCKED for claim/done/enqueue operations and configurable timeout.  
+   **Test strategy:** Contention test with long-running transaction and concurrent writers asserting retry success.  
+   **Confidence:** Medium.
+
+## PASS 3 — Persistence & Boundary Audit
+
+### Boundary Inventory
+- **DB open/init:** `openDB()` (`sql.Open`, schema `Exec`, PRAGMAs).
+- **Write paths:**
+  - `enqueueCmd()` → UPSERT queue rows.
+  - `doneCmd()` → UPDATE completion/revisit metadata.
+  - `resetCmd()` → DELETE by treatment.
+- **Read paths:**
+  - `claimCmd()` → SELECT pending by cursor/shard.
+  - `statusCmd()` → aggregate query + TOTAL row.
+- **Filesystem boundary:** `enqueueCmd()` → `fileHash()` (`os.Open` + `io.Copy`).
+
+### Findings
+
+1. **TOTAL status row can disappear for empty datasets due to NULL scan mismatch**  
+   **Severity:** Low  
+   **Evidence + boundary trace:** `statusCmd()` uses `SUM(...)` in TOTAL row; when `stats` is empty, SUM returns NULL; scan target fields are `int` and scan errors are ignored (`continue`).  
+   **Mechanism:** Empty-state reporting silently omits TOTAL row and can produce confusing/no output rows.  
+   **Concrete failure scenario:** New database queried with `status --json` returns unexpected empty array rather than explicit zero totals, confusing automation.  
+   **Minimal fix:** Wrap sums with `COALESCE(SUM(...),0)` and handle scan errors as fatal.  
+   **Test plan:** Add status test on empty DB expecting TOTAL=0 row in text and JSON modes.  
+   **Confidence:** Medium.
+
+2. **`claim` does not honor due-time boundary despite schema/README “Due” semantics**  
+   **Severity:** High  
+   **Evidence + boundary trace:** schema contains `next_at`; README defines “Due = next_at < NOW()”; `claimCmd()` query ignores `next_at`.  
+   **Mechanism:** Persistence model encodes due scheduling but read path never consumes it.  
+   **Concrete failure scenario:** Jobs with scheduled revisit accumulate indefinitely as done records and never run again.  
+   **Minimal fix:** Integrate due-time predicate in claim selection and update done/requeue semantics accordingly.  
+   **Test plan:** Round-trip test for enqueue → done(revisit) → simulated time advance → claim returns path.  
+   **Confidence:** High.


### PR DESCRIPTION
### Motivation
- Add a formal 3-pass true-bug audit to document correctness, concurrency, and persistence defects for the CLI-backed queue and provide concrete, testable remediation guidance.

### Description
- Add `docs/bug-audit-2026-02-24.md` containing PASS 1/2/3 analyses (system map, concrete findings, reachability notes, and minimal fixes); the report also records that `snipe` was unavailable so static call-tracing and test runs were used as a pragmatic fallback.

### Testing
- Ran `go test ./...` which succeeded (`ok github.com/dkoosis/next`), and attempted `snipe --help` which failed because `snipe` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d31e164508325882d341b1cad5d32)