### PR TITLE
feat: reconcile --units, op-spec-hash done-state, gc --stale (cc-plugins ccp-3gi.2)

### DIFF
--- a/main.go
+++ b/main.go
@@ -295,7 +295,13 @@ const upsertSQL = `
 	                      queue.result, NULL),
 	  next_at      = IIF(queue.content_hash = excluded.content_hash
 	                      AND COALESCE(queue.spec_hash,'') = COALESCE(excluded.spec_hash,''),
-	                      queue.next_at, NULL)
+	                      queue.next_at, NULL),
+	  claimed_at   = IIF(queue.content_hash = excluded.content_hash
+	                      AND COALESCE(queue.spec_hash,'') = COALESCE(excluded.spec_hash,''),
+	                      queue.claimed_at, NULL),
+	  claimed_by   = IIF(queue.content_hash = excluded.content_hash
+	                      AND COALESCE(queue.spec_hash,'') = COALESCE(excluded.spec_hash,''),
+	                      queue.claimed_by, NULL)
 `
 
 func enqueueCmd() {
@@ -846,7 +852,7 @@ Flags:
 	}
 	defer func() { _ = db.Close() }()
 
-	pruned, kept, err := reconcileFromStdin(db, *treatment)
+	pruned, kept, err := reconcileFromStdin(db, os.Stdin, *treatment)
 	if err != nil {
 		fatal("reconcile: %v", err)
 	}
@@ -883,12 +889,13 @@ func groundTruthHashes(r io.Reader) (map[string]bool, error) {
 }
 
 // reconcileFromStdin reads a newline-delimited ground-truth path list from
-// stdin and deletes any queue row for treatment whose path_hash is absent
-// from that list. Returns the pruned entries and the count kept.
-func reconcileFromStdin(db *sql.DB, treatment string) ([]PruneResult, int, error) {
+// r (os.Stdin in production) and deletes any queue row for treatment whose
+// path_hash is absent from that list. Returns the pruned entries and the
+// count kept.
+func reconcileFromStdin(db *sql.DB, r io.Reader, treatment string) ([]PruneResult, int, error) {
 	ctx := context.Background()
 
-	groundTruth, err := groundTruthHashes(os.Stdin)
+	groundTruth, err := groundTruthHashes(r)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -991,8 +998,8 @@ Flags:
 	if *stale == "" {
 		fatal("error: --stale required, e.g. --stale='30 days'")
 	}
-	if !validTimeModifier(*stale) {
-		fatal("error: --stale must be like '30 days', '12 hours'")
+	if !validLease(*stale) {
+		fatal("error: --stale must be a positive duration like '30 days', '12 hours'")
 	}
 
 	db, err := openDB(*dbPath)

--- a/main.go
+++ b/main.go
@@ -46,6 +46,10 @@ func main() {
 		statusCmd()
 	case "reset":
 		resetCmd()
+	case "reconcile":
+		reconcileCmd()
+	case "gc":
+		gcCmd()
 	case "help", "--help", "-h":
 		usage()
 	default:
@@ -72,11 +76,13 @@ Concepts:
   revisit      done --revisit schedules the entry to reappear after a duration.
 
 Commands:
-  enqueue   Read paths from stdin, upsert into queue
-  claim     Atomically claim unclaimed path(s), print to stdout
-  done      Mark a path as complete (silent on success)
-  status    Show pending/done counts per treatment
-  reset     Delete all entries for a treatment (destructive)
+  enqueue    Read paths from stdin, upsert into queue
+  claim      Atomically claim unclaimed path(s), print to stdout
+  done       Mark a path as complete (silent on success)
+  status     Show pending/done counts per treatment
+  reset      Delete all entries for a treatment (destructive)
+  reconcile  Prune queue entries absent from a piped ground-truth unit list
+  gc         Drop treatments with no activity in --stale duration (destructive)
 
 Per-command help: next <command> --help
 
@@ -84,8 +90,12 @@ Common flags (all commands):
   --db         Database path (default: .quality/ledger.db)
   --treatment  Treatment name (default: "default")
 
-Machine output: claim and status support --json for structured output.
+Machine output: claim, status, reconcile and gc support --json for structured output.
 Exit codes: 0 success, 1 error (message on stderr).
+
+Layering: next only diffs and prunes against what it's given — it never
+resolves ground truth itself (no go list, no globs). The caller resolves
+the current unit set and pipes it in via reconcile --units=-.
 
 Examples:
   find . -name '*.go' | next enqueue --treatment=lint
@@ -94,6 +104,8 @@ Examples:
   next done --path=bar.go --revisit='+14 days'
   next status --json
   next reset --treatment=lint --yes
+  go list -f '{{.Dir}}' ./... | next reconcile --units=- --treatment=lint
+  next gc --stale='30 days' --yes
 
 Parallel processing (sharding divides the hash space across workers):
   next claim --treatment=lint --shard=0 --total-shards=4 --n=100
@@ -214,8 +226,8 @@ func openDB(path string) (*sql.DB, error) {
 		return nil, fmt.Errorf("schema execution failed: %w", execErr)
 	}
 
-	// Migrate: add claim columns if missing (idempotent).
-	for _, col := range []string{"claimed_at", "claimed_by"} {
+	// Migrate: add claim/spec/activity columns if missing (idempotent).
+	for _, col := range []string{"claimed_at", "claimed_by", "spec_hash", "updated_at"} {
 		_, alterErr := db.ExecContext(ctx, `ALTER TABLE queue ADD COLUMN `+col+` TEXT`)
 		if alterErr != nil && !strings.Contains(alterErr.Error(), "duplicate column") {
 			_ = db.Close()
@@ -223,10 +235,15 @@ func openDB(path string) (*sql.DB, error) {
 		}
 	}
 
-	// Index on claimed_at — created after migration so it works on upgraded DBs.
-	if _, execErr := db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_queue_claimed_at ON queue(claimed_at)`); execErr != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("index creation failed: %w", execErr)
+	// Indexes created after migration so they work on upgraded DBs.
+	for _, idx := range []string{
+		`CREATE INDEX IF NOT EXISTS idx_queue_claimed_at ON queue(claimed_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_queue_treatment_updated ON queue(treatment, updated_at)`,
+	} {
+		if _, execErr := db.ExecContext(ctx, idx); execErr != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("index creation failed: %w", execErr)
+		}
 	}
 
 	return db, nil
@@ -253,31 +270,48 @@ func fatal(format string, args ...any) {
 // ----------------------------------------
 
 // upsertSQL is the UPSERT statement for enqueue. Content-change detection
-// re-activates a job by clearing done_at/result/next_at when the hash differs.
+// re-activates a job by clearing done_at/result/next_at when the content
+// hash OR the op-spec hash differs from what was last recorded — a unit
+// unchanged by name but changed in content, or reprocessed under a changed
+// op spec, is not done. COALESCE(...,'') treats NULL and '' as equal so
+// pre-migration rows (spec_hash NULL) and callers that omit --spec-hash
+// (spec_hash '') compare sanely instead of always mismatching.
 //
 //nolint:dupword // SQL NULL repetition is intentional
 const upsertSQL = `
 	INSERT INTO queue
-	  (path, path_hash, content_hash, treatment, done_at, result, next_at)
-	VALUES (?, ?, ?, ?, NULL, NULL, NULL)
+	  (path, path_hash, content_hash, spec_hash, treatment, done_at, result, next_at, updated_at)
+	VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL, DATETIME('now'))
 	ON CONFLICT(path_hash, treatment) DO UPDATE SET
 	  path         = excluded.path,
 	  content_hash = excluded.content_hash,
-	  done_at      = IIF(queue.content_hash = excluded.content_hash, queue.done_at, NULL),
-	  result       = IIF(queue.content_hash = excluded.content_hash, queue.result, NULL),
-	  next_at      = IIF(queue.content_hash = excluded.content_hash, queue.next_at, NULL)
+	  spec_hash    = excluded.spec_hash,
+	  updated_at   = DATETIME('now'),
+	  done_at      = IIF(queue.content_hash = excluded.content_hash
+	                      AND COALESCE(queue.spec_hash,'') = COALESCE(excluded.spec_hash,''),
+	                      queue.done_at, NULL),
+	  result       = IIF(queue.content_hash = excluded.content_hash
+	                      AND COALESCE(queue.spec_hash,'') = COALESCE(excluded.spec_hash,''),
+	                      queue.result, NULL),
+	  next_at      = IIF(queue.content_hash = excluded.content_hash
+	                      AND COALESCE(queue.spec_hash,'') = COALESCE(excluded.spec_hash,''),
+	                      queue.next_at, NULL)
 `
 
 func enqueueCmd() {
 	fs := flag.NewFlagSet("enqueue", flag.ExitOnError)
 	treatment := fs.String("treatment", "default", "treatment name")
 	dbPath := fs.String("db", defaultDBPath, "database path")
+	specHash := fs.String("spec-hash", "", "op-spec hash; changing it reopens done units even if content is unchanged")
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, `Usage: next enqueue [--treatment=NAME] [--db=PATH]
+		fmt.Fprintf(os.Stderr, `Usage: next enqueue [--treatment=NAME] [--spec-hash=HASH] [--db=PATH]
 
 Read file paths from stdin (one per line), upsert into the queue.
 Paths are converted to absolute. Empty lines are skipped.
-If a path's content hash changed since last enqueue, it is re-enqueued (done_at cleared).
+Done-state is keyed on content_hash(path) + --spec-hash. If a path's content
+hash changed since last enqueue, OR --spec-hash differs from what was last
+recorded for it, it is re-enqueued (done_at cleared) even though its name
+is unchanged.
 
 Stdin:  one file path per line
 Stdout: "enqueued N paths for treatment=NAME"
@@ -294,7 +328,7 @@ Flags:
 		fatal("db error: %v", err)
 	}
 
-	count, err := enqueueFromStdin(db, *treatment)
+	count, err := enqueueFromStdin(db, *treatment, *specHash)
 	if err != nil {
 		_ = db.Close()
 		fatal("enqueue: %v", err)
@@ -303,7 +337,7 @@ Flags:
 	_ = db.Close()
 }
 
-func enqueueFromStdin(db *sql.DB, treatment string) (int, error) {
+func enqueueFromStdin(db *sql.DB, treatment, specHash string) (int, error) {
 	ctx := context.Background()
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
@@ -336,7 +370,7 @@ func enqueueFromStdin(db *sql.DB, treatment string) (int, error) {
 			continue
 		}
 
-		if _, err := stmt.ExecContext(ctx, absPath, ph, ch, treatment); err != nil {
+		if _, err := stmt.ExecContext(ctx, absPath, ph, ch, specHash, treatment); err != nil {
 			_ = tx.Rollback()
 			return 0, fmt.Errorf("insert %q: %w", absPath, err)
 		}
@@ -511,7 +545,7 @@ func buildClaimQuery(treatment, cursor, worker, lease string, n, shard, totalSha
 	// Outer UPDATE atomically claims those rows.
 	query := fmt.Sprintf(`
 		UPDATE queue
-		   SET claimed_at = DATETIME('now'), claimed_by = ?
+		   SET claimed_at = DATETIME('now'), claimed_by = ?, updated_at = DATETIME('now')
 		 WHERE rowid IN (%s)
 		 RETURNING path, path_hash`, inner)
 	args = append([]any{worker}, args...)
@@ -596,7 +630,8 @@ func markDone(db *sql.DB, pathHash, treatment, result, revisit string) error {
 		UPDATE queue
 		   SET done_at = ?, result = ?,
 		       next_at = IIF(? = '', NULL, DATETIME('now', ?)),
-		       claimed_at = NULL, claimed_by = NULL
+		       claimed_at = NULL, claimed_by = NULL,
+		       updated_at = DATETIME('now')
 		 WHERE path_hash = ? AND treatment = ?
 	`, now, result, revisit, revisit, pathHash, treatment)
 	if err != nil {
@@ -704,6 +739,19 @@ WITH stats AS (
 // reset
 // ----------------------------------------
 
+// confirmed returns true immediately if skip is set (e.g. --yes). Otherwise
+// it prints prompt + " [y/N] ", reads one line from stdin, and returns
+// whether the response was y/Y.
+func confirmed(skip bool, prompt string) bool {
+	if skip {
+		return true
+	}
+	fmt.Printf("%s [y/N] ", prompt)
+	var response string
+	_, _ = fmt.Scanln(&response)
+	return response == "y" || response == "Y"
+}
+
 func resetCmd() {
 	fs := flag.NewFlagSet("reset", flag.ExitOnError)
 	treatment := fs.String("treatment", "", "treatment to reset (required)")
@@ -728,14 +776,9 @@ Flags:
 	if *treatment == "" {
 		fatal("error: --treatment required")
 	}
-	if !*confirm {
-		fmt.Printf("Delete all entries for treatment=%s? [y/N] ", *treatment)
-		var response string
-		_, _ = fmt.Scanln(&response)
-		if response != "y" && response != "Y" {
-			fmt.Println("canceled")
-			return
-		}
+	if !confirmed(*confirm, fmt.Sprintf("Delete all entries for treatment=%s?", *treatment)) {
+		fmt.Println("canceled")
+		return
 	}
 
 	db, err := openDB(*dbPath)
@@ -754,4 +797,307 @@ Flags:
 		fatal("rows affected: %v", err)
 	}
 	fmt.Printf("deleted %d entries\n", n)
+}
+
+// ----------------------------------------
+// reconcile
+// ----------------------------------------
+
+// PruneResult holds a queue entry pruned by reconcile.
+type PruneResult struct {
+	Path     string `json:"path"`
+	PathHash string `json:"path_hash"`
+}
+
+func reconcileCmd() {
+	fs := flag.NewFlagSet("reconcile", flag.ExitOnError)
+	treatment := fs.String("treatment", "default", "treatment name")
+	dbPath := fs.String("db", defaultDBPath, "database path")
+	units := fs.String("units", "-", "ground-truth unit list source; only '-' (stdin) is supported")
+	jsonOutput := fs.Bool("json", false, "output pruned entries as a JSON array")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `Usage: next reconcile --units=- [--treatment=NAME] [--db=PATH] [--json]
+
+Diff a ground-truth unit list against the queue for --treatment. Any queued
+path whose path_hash is NOT present in the piped list is pruned (deleted) —
+the "vanished units" half of zombie-data cleanup.
+
+LAYERING: next only diffs and prunes what it's given. It does not resolve
+ground truth itself (no go list, no glob walk) — the caller resolves the
+current unit set and pipes it in via --units=-.
+
+Stdin (--units=-): one path per line (absolute or relative; empty lines skipped)
+Stdout: "reconciled: N pruned, M kept for treatment=NAME" (or JSON array of
+        pruned {path, path_hash} with --json)
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(os.Args[2:])
+
+	if *units != "-" {
+		fatal("error: --units only supports '-' (stdin) — next does not resolve ground truth itself")
+	}
+
+	db, err := openDB(*dbPath)
+	if err != nil {
+		fatal("db error: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	pruned, kept, err := reconcileFromStdin(db, *treatment)
+	if err != nil {
+		fatal("reconcile: %v", err)
+	}
+
+	if *jsonOutput {
+		writeJSON(pruned)
+		return
+	}
+	fmt.Printf("reconciled: %d pruned, %d kept for treatment=%s\n", len(pruned), kept, *treatment)
+}
+
+// groundTruthHashes reads a newline-delimited path list from r and returns
+// the set of path_hash(absPath) it names. Unreadable lines (bad abs-path
+// resolution) are skipped with a warning, not fatal.
+func groundTruthHashes(r io.Reader) (map[string]bool, error) {
+	groundTruth := map[string]bool{}
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		absPath, err := filepath.Abs(line)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping %q: %v\n", line, err)
+			continue
+		}
+		groundTruth[pathHash(absPath)] = true
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading stdin: %w", err)
+	}
+	return groundTruth, nil
+}
+
+// reconcileFromStdin reads a newline-delimited ground-truth path list from
+// stdin and deletes any queue row for treatment whose path_hash is absent
+// from that list. Returns the pruned entries and the count kept.
+func reconcileFromStdin(db *sql.DB, treatment string) ([]PruneResult, int, error) {
+	ctx := context.Background()
+
+	groundTruth, err := groundTruthHashes(os.Stdin)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("begin tx: %w", err)
+	}
+
+	rows, err := tx.QueryContext(ctx, "SELECT path, path_hash FROM queue WHERE treatment = ?", treatment)
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, 0, fmt.Errorf("select: %w", err)
+	}
+	existing, err := scanPathRows(rows)
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, 0, err
+	}
+
+	stmt, err := tx.PrepareContext(ctx, "DELETE FROM queue WHERE path_hash = ? AND treatment = ?")
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, 0, fmt.Errorf("prepare delete: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+
+	pruned := []PruneResult{}
+	kept := 0
+	for _, e := range existing {
+		if groundTruth[e.hash] {
+			kept++
+			continue
+		}
+		if _, err := stmt.ExecContext(ctx, e.hash, treatment); err != nil {
+			_ = tx.Rollback()
+			return nil, 0, fmt.Errorf("delete %q: %w", e.path, err)
+		}
+		pruned = append(pruned, PruneResult{Path: e.path, PathHash: e.hash})
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, 0, fmt.Errorf("commit: %w", err)
+	}
+	return pruned, kept, nil
+}
+
+type pathHashRow struct{ path, hash string }
+
+func scanPathRows(rows *sql.Rows) ([]pathHashRow, error) {
+	defer func() { _ = rows.Close() }()
+	var out []pathHashRow
+	for rows.Next() {
+		var r pathHashRow
+		if err := rows.Scan(&r.path, &r.hash); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return out, nil
+}
+
+// ----------------------------------------
+// gc
+// ----------------------------------------
+
+// GCResult holds a treatment dropped by gc, and how many entries it held.
+type GCResult struct {
+	Treatment string `json:"treatment"`
+	Count     int    `json:"count"`
+}
+
+func gcCmd() {
+	fs := flag.NewFlagSet("gc", flag.ExitOnError)
+	dbPath := fs.String("db", defaultDBPath, "database path")
+	stale := fs.String("stale", "", "drop treatments with no activity in this duration, e.g. '30 days' (required)")
+	confirm := fs.Bool("yes", false, "skip confirmation")
+	jsonOutput := fs.Bool("json", false, "output dropped treatments as a JSON array")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `Usage: next gc --stale=DURATION [--yes] [--db=PATH] [--json]
+
+Drop (delete) ALL queue entries for every treatment with no activity
+(enqueue, claim, or done) in --stale duration. Destructive and irreversible.
+Prompts for confirmation unless --yes is passed. Always use --yes in scripts.
+
+--stale is required, e.g. '30 days', '12 hours'.
+
+Stdout: "gc: dropped treatment=NAME (N entries)" per dropped treatment
+        (or JSON array of {treatment, count} with --json)
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(os.Args[2:])
+
+	if *stale == "" {
+		fatal("error: --stale required, e.g. --stale='30 days'")
+	}
+	if !validTimeModifier(*stale) {
+		fatal("error: --stale must be like '30 days', '12 hours'")
+	}
+
+	db, err := openDB(*dbPath)
+	if err != nil {
+		fatal("db error: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	treatments, err := staleTreatments(db, normalizeLease(*stale))
+	if err != nil {
+		fatal("gc: %v", err)
+	}
+
+	if len(treatments) == 0 {
+		if *jsonOutput {
+			writeJSON([]GCResult{})
+			return
+		}
+		fmt.Println("gc: no stale treatments")
+		return
+	}
+
+	prompt := fmt.Sprintf("Drop %d stale treatment(s): %s?", len(treatments), strings.Join(treatments, ", "))
+	if !confirmed(*confirm, prompt) {
+		fmt.Println("canceled")
+		return
+	}
+
+	dropped, err := dropTreatments(db, treatments)
+	if err != nil {
+		fatal("gc: %v", err)
+	}
+
+	if *jsonOutput {
+		writeJSON(dropped)
+		return
+	}
+	for _, d := range dropped {
+		fmt.Printf("gc: dropped treatment=%s (%d entries)\n", d.Treatment, d.Count)
+	}
+}
+
+// staleTreatments returns treatment names whose most recent activity
+// (updated_at, bumped by enqueue/claim/done) is older than the given
+// SQLite duration modifier (e.g. "30 days"). Pre-migration rows with a
+// NULL updated_at are treated as maximally stale.
+func staleTreatments(db *sql.DB, staleModifier string) ([]string, error) {
+	rows, err := db.QueryContext(context.Background(), `
+		SELECT treatment
+		  FROM queue
+		 GROUP BY treatment
+		HAVING MAX(COALESCE(updated_at, '1970-01-01 00:00:00')) <= DATETIME('now', '-' || ?)
+	`, staleModifier)
+	if err != nil {
+		return nil, fmt.Errorf("query stale treatments: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return out, nil
+}
+
+// dropTreatments deletes every queue entry for each given treatment,
+// returning the count dropped per treatment.
+func dropTreatments(db *sql.DB, treatments []string) ([]GCResult, error) {
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+
+	stmt, err := tx.PrepareContext(ctx, "DELETE FROM queue WHERE treatment = ?")
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, fmt.Errorf("prepare: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+
+	results := make([]GCResult, 0, len(treatments))
+	for _, t := range treatments {
+		res, err := stmt.ExecContext(ctx, t)
+		if err != nil {
+			_ = tx.Rollback()
+			return nil, fmt.Errorf("delete %q: %w", t, err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			_ = tx.Rollback()
+			return nil, fmt.Errorf("rows affected %q: %w", t, err)
+		}
+		results = append(results, GCResult{Treatment: t, Count: int(n)})
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+	return results, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1312,6 +1312,21 @@ func TestEnqueueCmd_ReactivatesEntry_When_SpecHashChanges(t *testing.T) {
 	if doneAt.Valid {
 		t.Fatal("expected done_at to be NULL after spec-hash change even though content is unchanged")
 	}
+
+	// A reopened unit must also shed any active lease — otherwise a claimed
+	// row stays locked until lease expiry even though it needs a re-run.
+	if _, err := db.Exec("UPDATE queue SET claimed_at = DATETIME('now'), claimed_by = 'w1' WHERE path_hash = ?", ph); err != nil {
+		t.Fatalf("set claim: %v", err)
+	}
+	runEnqueue("v3")
+
+	var claimedAt, claimedBy sql.NullString
+	if err := db.QueryRow("SELECT claimed_at, claimed_by FROM queue WHERE path_hash = ?", ph).Scan(&claimedAt, &claimedBy); err != nil {
+		t.Fatalf("scan claim after spec-hash change: %v", err)
+	}
+	if claimedAt.Valid || claimedBy.Valid {
+		t.Fatal("expected claimed_at/claimed_by to be NULL after spec-hash change reopened the unit")
+	}
 }
 
 func TestEnqueueCmd_StaysDone_When_ContentAndSpecHashUnchanged(t *testing.T) {
@@ -1399,20 +1414,7 @@ func TestReconcileFromStdin_PrunesVanishedUnits_When_AbsentFromGroundTruth(t *te
 		t.Fatalf("insert vanished: %v", err)
 	}
 
-	oldStdin := os.Stdin
-	r, w, perr := os.Pipe()
-	if perr != nil {
-		t.Fatalf("pipe: %v", perr)
-	}
-	os.Stdin = r
-	defer func() { os.Stdin = oldStdin }()
-
-	go func() {
-		_, _ = fmt.Fprintln(w, survivorPath)
-		_ = w.Close()
-	}()
-
-	pruned, kept, err := reconcileFromStdin(db, "lint")
+	pruned, kept, err := reconcileFromStdin(db, strings.NewReader(survivorPath+"\n"), "lint")
 	if err != nil {
 		t.Fatalf("reconcileFromStdin: %v", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -688,7 +688,7 @@ func TestEnqueueCmd_ReactivatesEntry_When_DirectoryContentChanges(t *testing.T) 
 	defer func() { _ = db.Close() }()
 
 	ch1, _ := dirHash(absPkg)
-	if _, err := db.Exec(upsertSQL, absPkg, ph, ch1, "lint"); err != nil {
+	if _, err := db.Exec(upsertSQL, absPkg, ph, ch1, "", "lint"); err != nil {
 		t.Fatalf("insert: %v", err)
 	}
 
@@ -713,7 +713,7 @@ func TestEnqueueCmd_ReactivatesEntry_When_DirectoryContentChanges(t *testing.T) 
 	if ch1 == ch2 {
 		t.Fatal("dirHash should have changed")
 	}
-	if _, err := db.Exec(upsertSQL, absPkg, ph, ch2, "lint"); err != nil {
+	if _, err := db.Exec(upsertSQL, absPkg, ph, ch2, "", "lint"); err != nil {
 		t.Fatalf("re-insert: %v", err)
 	}
 
@@ -1234,5 +1234,369 @@ func TestMarkDone_SetsNextAt_When_RevisitValid(t *testing.T) {
 	}
 	if !nextAt.Valid {
 		t.Fatal("next_at should be set for valid revisit modifier")
+	}
+}
+
+// ----------------------------------------
+// content-hash + op-spec-hash done-state
+// ----------------------------------------
+
+func TestEnqueueCmd_ReactivatesEntry_When_SpecHashChanges(t *testing.T) {
+	tmpDir := setupWorkDir(t)
+	dbPath := filepath.Join(tmpDir, "ledger.db")
+
+	validFile := filepath.Join(tmpDir, "unit.go")
+	if err := os.WriteFile(validFile, []byte("package unit"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	absPath, err := filepath.Abs(validFile)
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	ph := pathHash(absPath)
+
+	runEnqueue := func(specHash string) {
+		inputFile, cerr := os.CreateTemp(tmpDir, "input")
+		if cerr != nil {
+			t.Fatalf("create temp input: %v", cerr)
+		}
+		defer func() { _ = inputFile.Close() }()
+		_, _ = fmt.Fprintln(inputFile, absPath)
+		if _, serr := inputFile.Seek(0, 0); serr != nil {
+			t.Fatalf("seek: %v", serr)
+		}
+
+		oldArgs := os.Args
+		args := []string{"next", "enqueue", "--db", dbPath, "--treatment", "lint"}
+		if specHash != "" {
+			args = append(args, "--spec-hash", specHash)
+		}
+		os.Args = args
+		defer func() { os.Args = oldArgs }()
+
+		oldStdin := os.Stdin
+		os.Stdin = inputFile
+		defer func() { os.Stdin = oldStdin }()
+
+		captureStdout(t, func() { enqueueCmd() })
+	}
+
+	// First enqueue under spec "v1", mark done.
+	runEnqueue("v1")
+
+	db, err := openDB(dbPath)
+	if err != nil {
+		t.Fatalf("openDB verify: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := markDone(db, ph, "lint", "result", ""); err != nil {
+		t.Fatalf("markDone: %v", err)
+	}
+
+	var doneAt sql.NullString
+	if err := db.QueryRow("SELECT done_at FROM queue WHERE path_hash = ?", ph).Scan(&doneAt); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !doneAt.Valid {
+		t.Fatal("expected done_at set after markDone")
+	}
+
+	// Content is unchanged, but the op spec changed ("v1" -> "v2") — the
+	// unit must reopen even though its name and bytes are identical.
+	runEnqueue("v2")
+
+	if err := db.QueryRow("SELECT done_at FROM queue WHERE path_hash = ?", ph).Scan(&doneAt); err != nil {
+		t.Fatalf("scan after spec-hash change: %v", err)
+	}
+	if doneAt.Valid {
+		t.Fatal("expected done_at to be NULL after spec-hash change even though content is unchanged")
+	}
+}
+
+func TestEnqueueCmd_StaysDone_When_ContentAndSpecHashUnchanged(t *testing.T) {
+	tmpDir := setupWorkDir(t)
+	dbPath := filepath.Join(tmpDir, "ledger.db")
+
+	validFile := filepath.Join(tmpDir, "unit.go")
+	if err := os.WriteFile(validFile, []byte("package unit"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	absPath, err := filepath.Abs(validFile)
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	ph := pathHash(absPath)
+
+	runEnqueue := func() {
+		inputFile, cerr := os.CreateTemp(tmpDir, "input")
+		if cerr != nil {
+			t.Fatalf("create temp input: %v", cerr)
+		}
+		defer func() { _ = inputFile.Close() }()
+		_, _ = fmt.Fprintln(inputFile, absPath)
+		if _, serr := inputFile.Seek(0, 0); serr != nil {
+			t.Fatalf("seek: %v", serr)
+		}
+
+		oldArgs := os.Args
+		os.Args = []string{"next", "enqueue", "--db", dbPath, "--treatment", "lint", "--spec-hash", "same"}
+		defer func() { os.Args = oldArgs }()
+
+		oldStdin := os.Stdin
+		os.Stdin = inputFile
+		defer func() { os.Stdin = oldStdin }()
+
+		captureStdout(t, func() { enqueueCmd() })
+	}
+
+	runEnqueue()
+
+	db, err := openDB(dbPath)
+	if err != nil {
+		t.Fatalf("openDB verify: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := markDone(db, ph, "lint", "result", ""); err != nil {
+		t.Fatalf("markDone: %v", err)
+	}
+
+	// Re-enqueue with identical content and identical spec-hash.
+	runEnqueue()
+
+	var doneAt sql.NullString
+	if err := db.QueryRow("SELECT done_at FROM queue WHERE path_hash = ?", ph).Scan(&doneAt); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !doneAt.Valid {
+		t.Fatal("expected done_at to remain set when content and spec-hash are both unchanged")
+	}
+}
+
+// ----------------------------------------
+// reconcile
+// ----------------------------------------
+
+func TestReconcileFromStdin_PrunesVanishedUnits_When_AbsentFromGroundTruth(t *testing.T) {
+	tmpDir := setupWorkDir(t)
+	dbPath := filepath.Join(tmpDir, "ledger.db")
+	db, err := openDB(dbPath)
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	survivorPath := filepath.Join(tmpDir, "survivor.go")
+	vanishedPath := filepath.Join(tmpDir, "vanished.go")
+	survivorHash := pathHash(survivorPath)
+	vanishedHash := pathHash(vanishedPath)
+
+	if _, err := db.Exec(testInsertSQL, survivorPath, survivorHash, "ch1", "lint"); err != nil {
+		t.Fatalf("insert survivor: %v", err)
+	}
+	if _, err := db.Exec(testInsertSQL, vanishedPath, vanishedHash, "ch2", "lint"); err != nil {
+		t.Fatalf("insert vanished: %v", err)
+	}
+
+	oldStdin := os.Stdin
+	r, w, perr := os.Pipe()
+	if perr != nil {
+		t.Fatalf("pipe: %v", perr)
+	}
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	go func() {
+		_, _ = fmt.Fprintln(w, survivorPath)
+		_ = w.Close()
+	}()
+
+	pruned, kept, err := reconcileFromStdin(db, "lint")
+	if err != nil {
+		t.Fatalf("reconcileFromStdin: %v", err)
+	}
+	if kept != 1 {
+		t.Fatalf("kept = %d, want 1", kept)
+	}
+	if len(pruned) != 1 || pruned[0].Path != vanishedPath {
+		t.Fatalf("pruned = %+v, want [%s]", pruned, vanishedPath)
+	}
+
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM queue WHERE treatment='lint'").Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("remaining rows = %d, want 1", count)
+	}
+
+	var remainingPath string
+	if err := db.QueryRow("SELECT path FROM queue WHERE treatment='lint'").Scan(&remainingPath); err != nil {
+		t.Fatalf("scan remaining: %v", err)
+	}
+	if remainingPath != survivorPath {
+		t.Fatalf("remaining path = %s, want %s", remainingPath, survivorPath)
+	}
+}
+
+func TestReconcileCmd_ReportsPrunedAndKept_When_RunViaCmd(t *testing.T) {
+	tmpDir := setupWorkDir(t)
+	dbPath := filepath.Join(tmpDir, "ledger.db")
+	db, err := openDB(dbPath)
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+
+	survivorPath := filepath.Join(tmpDir, "keep.go")
+	vanishedPath := filepath.Join(tmpDir, "gone.go")
+	if _, err := db.Exec(testInsertSQL, survivorPath, pathHash(survivorPath), "ch1", "sweep"); err != nil {
+		t.Fatalf("insert survivor: %v", err)
+	}
+	if _, err := db.Exec(testInsertSQL, vanishedPath, pathHash(vanishedPath), "ch2", "sweep"); err != nil {
+		t.Fatalf("insert vanished: %v", err)
+	}
+	_ = db.Close()
+
+	inputFile, err := os.CreateTemp(tmpDir, "units")
+	if err != nil {
+		t.Fatalf("create temp input: %v", err)
+	}
+	defer func() { _ = inputFile.Close() }()
+	_, _ = fmt.Fprintln(inputFile, survivorPath)
+	if _, err := inputFile.Seek(0, 0); err != nil {
+		t.Fatalf("seek: %v", err)
+	}
+
+	oldArgs := os.Args
+	os.Args = []string{"next", "reconcile", "--db", dbPath, "--treatment", "sweep", "--units", "-"}
+	defer func() { os.Args = oldArgs }()
+
+	oldStdin := os.Stdin
+	os.Stdin = inputFile
+	defer func() { os.Stdin = oldStdin }()
+
+	output := captureStdout(t, func() { reconcileCmd() })
+
+	if !strings.Contains(output, "reconciled: 1 pruned, 1 kept for treatment=sweep") {
+		t.Fatalf("unexpected output: %q", output)
+	}
+}
+
+// ----------------------------------------
+// gc
+// ----------------------------------------
+
+func TestStaleTreatments_ReturnsOnlyStale_When_MixedActivity(t *testing.T) {
+	tmpDir := setupWorkDir(t)
+	dbPath := filepath.Join(tmpDir, "ledger.db")
+	db, err := openDB(dbPath)
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	freshPath := filepath.Join(tmpDir, "fresh.go")
+	stalePath := filepath.Join(tmpDir, "stale.go")
+
+	if _, err := db.Exec(
+		"INSERT INTO queue (path, path_hash, content_hash, treatment, updated_at) VALUES (?, ?, ?, ?, DATETIME('now'))",
+		freshPath, pathHash(freshPath), "ch1", "fresh-treatment",
+	); err != nil {
+		t.Fatalf("insert fresh: %v", err)
+	}
+	if _, err := db.Exec(
+		"INSERT INTO queue (path, path_hash, content_hash, treatment, updated_at) VALUES (?, ?, ?, ?, DATETIME('now', '-60 days'))",
+		stalePath, pathHash(stalePath), "ch2", "stale-treatment",
+	); err != nil {
+		t.Fatalf("insert stale: %v", err)
+	}
+
+	stale, err := staleTreatments(db, "30 days")
+	if err != nil {
+		t.Fatalf("staleTreatments: %v", err)
+	}
+	if len(stale) != 1 || stale[0] != "stale-treatment" {
+		t.Fatalf("stale = %v, want [stale-treatment]", stale)
+	}
+}
+
+func TestGCCmd_DropsStaleTreatment_When_ConfirmedViaYesFlag(t *testing.T) {
+	tmpDir := setupWorkDir(t)
+	dbPath := filepath.Join(tmpDir, "ledger.db")
+	db, err := openDB(dbPath)
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+
+	stalePath := filepath.Join(tmpDir, "stale.go")
+	freshPath := filepath.Join(tmpDir, "fresh.go")
+	if _, err := db.Exec(
+		"INSERT INTO queue (path, path_hash, content_hash, treatment, updated_at) VALUES (?, ?, ?, ?, DATETIME('now', '-60 days'))",
+		stalePath, pathHash(stalePath), "ch1", "old",
+	); err != nil {
+		t.Fatalf("insert stale: %v", err)
+	}
+	if _, err := db.Exec(
+		"INSERT INTO queue (path, path_hash, content_hash, treatment, updated_at) VALUES (?, ?, ?, ?, DATETIME('now'))",
+		freshPath, pathHash(freshPath), "ch2", "current",
+	); err != nil {
+		t.Fatalf("insert fresh: %v", err)
+	}
+	_ = db.Close()
+
+	oldArgs := os.Args
+	os.Args = []string{"next", "gc", "--db", dbPath, "--stale", "30 days", "--yes"}
+	defer func() { os.Args = oldArgs }()
+
+	output := captureStdout(t, func() { gcCmd() })
+	if !strings.Contains(output, "gc: dropped treatment=old (1 entries)") {
+		t.Fatalf("unexpected output: %q", output)
+	}
+
+	db2, err := openDB(dbPath)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = db2.Close() }()
+
+	var oldCount, currentCount int
+	if err := db2.QueryRow("SELECT COUNT(*) FROM queue WHERE treatment='old'").Scan(&oldCount); err != nil {
+		t.Fatalf("count old: %v", err)
+	}
+	if err := db2.QueryRow("SELECT COUNT(*) FROM queue WHERE treatment='current'").Scan(&currentCount); err != nil {
+		t.Fatalf("count current: %v", err)
+	}
+	if oldCount != 0 {
+		t.Fatalf("old treatment count = %d, want 0", oldCount)
+	}
+	if currentCount != 1 {
+		t.Fatalf("current treatment count = %d, want 1", currentCount)
+	}
+}
+
+func TestGCCmd_ReportsNoStale_When_AllTreatmentsFresh(t *testing.T) {
+	tmpDir := setupWorkDir(t)
+	dbPath := filepath.Join(tmpDir, "ledger.db")
+	db, err := openDB(dbPath)
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	freshPath := filepath.Join(tmpDir, "fresh.go")
+	if _, err := db.Exec(
+		"INSERT INTO queue (path, path_hash, content_hash, treatment, updated_at) VALUES (?, ?, ?, ?, DATETIME('now'))",
+		freshPath, pathHash(freshPath), "ch1", "current",
+	); err != nil {
+		t.Fatalf("insert fresh: %v", err)
+	}
+	_ = db.Close()
+
+	oldArgs := os.Args
+	os.Args = []string{"next", "gc", "--db", dbPath, "--stale", "30 days", "--yes"}
+	defer func() { os.Args = oldArgs }()
+
+	output := captureStdout(t, func() { gcCmd() })
+	if !strings.Contains(output, "gc: no stale treatments") {
+		t.Fatalf("unexpected output: %q", output)
 	}
 }

--- a/schema.sql
+++ b/schema.sql
@@ -2,13 +2,19 @@ CREATE TABLE IF NOT EXISTS queue (
   path          TEXT NOT NULL,
   path_hash     TEXT NOT NULL,
   content_hash  TEXT NOT NULL,
+  spec_hash     TEXT,
   treatment     TEXT NOT NULL,
   done_at       TEXT,
   result        TEXT,
   next_at       TEXT,
   claimed_at    TEXT,
   claimed_by    TEXT,
+  updated_at    TEXT,
   PRIMARY KEY (path_hash, treatment)
 );
 CREATE INDEX IF NOT EXISTS idx_queue_treatment_done ON queue(treatment, done_at);
 CREATE INDEX IF NOT EXISTS idx_queue_next_at ON queue(next_at);
+-- idx_queue_treatment_updated is created in Go (openDB) after migration, not
+-- here: on an old on-disk DB this CREATE TABLE IF NOT EXISTS is a no-op, so
+-- an index referencing updated_at here would fail before the ALTER TABLE
+-- migration adds that column.


### PR DESCRIPTION
Sweep-epic support (cc-plugins ccp-3gi.2): gives the queue a regeneration path so sweep state can't rot.

- `next reconcile --units=-` — diff a piped ground-truth list against a treatment's queue, prune vanished units. Zero resolution logic in next (layering: caller resolves, next diffs).
- Done-state now keys on content_hash + new spec_hash (`--spec-hash` on enqueue): unit unchanged by name but changed in content OR op-spec reopens. NULL/'' treated equal so existing callers don't spuriously reopen.
- `next gc --stale=DURATION` — drop treatments with no activity in the window (new `updated_at` bumped by enqueue/claim/done); confirm-gated like reset.

go test -count=1 -cover ./... green (70.5%). Demo transcript in the bead audit trail.

Note: repo-root `next` binary is tracked and predates this change — `go install` after merge to refresh `~/go/bin/next`.

Closes ccp-3gi.2 (bead in cc-plugins tracker)